### PR TITLE
Fixes create EHR and linked test

### DIFF
--- a/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestEhrEndpoint.java
+++ b/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestEhrEndpoint.java
@@ -18,9 +18,6 @@
 package org.ehrbase.client.openehrclient.defaultrestclient;
 
 import com.nedap.archie.rm.ehr.EhrStatus;
-import com.nedap.archie.rm.generic.PartySelf;
-import com.nedap.archie.rm.support.identification.HierObjectId;
-import com.nedap.archie.rm.support.identification.PartyRef;
 import org.ehrbase.client.openehrclient.EhrEndpoint;
 import org.ehrbase.client.openehrclient.VersionUid;
 
@@ -40,17 +37,12 @@ public class DefaultRestEhrEndpoint implements EhrEndpoint {
 
     @Override
     public UUID createEhr() {
-        EhrStatus ehrStatus = new EhrStatus();
-        PartySelf partySelf = new PartySelf(new PartyRef(new HierObjectId(UUID.randomUUID().toString()), "default", null));
-        ehrStatus.setSubject(partySelf);
-
-        return httpPost(defaultRestClient.getConfig().getBaseUri().resolve(EHR_PATH), ehrStatus).getUuid();
+        return httpPost(defaultRestClient.getConfig().getBaseUri().resolve(EHR_PATH), null).getUuid();
     }
 
 
     @Override
     public Optional<EhrStatus> getEhrStatus(UUID ehrId) {
-
         return httpGet(defaultRestClient.getConfig().getBaseUri().resolve(EHR_PATH + ehrId.toString() + EHR_STATUS_PATH), EhrStatus.class);
     }
 

--- a/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestEhrFieldsEndpointIT.java
+++ b/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestEhrFieldsEndpointIT.java
@@ -18,6 +18,7 @@
 package org.ehrbase.client.openehrclient.defaultrestclient;
 
 import com.nedap.archie.rm.datastructures.ItemTree;
+import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.ehr.EhrStatus;
 import com.nedap.archie.rm.generic.PartySelf;
 import com.nedap.archie.rm.support.identification.HierObjectId;
@@ -74,11 +75,12 @@ public class DefaultRestEhrFieldsEndpointIT {
         ehrStatus.setQueryable(false);
         ehrStatus.setModifiable(false);
         HierObjectId subjectId = new HierObjectId("6ee110de-08f8-4fac-8372-820650f150a9");
-        ehrStatus.setSubject(new PartySelf(new PartyRef(subjectId, "default", null)));
+        ehrStatus.setSubject(new PartySelf(new PartyRef(subjectId, "default", "PERSON")));
 
         String value = IOUtils.toString(ItemStruktureTestDataCanonicalJson.SIMPLE_EHR_OTHER_Details.getStream(), UTF_8);
         ehrStatus.setOtherDetails(new CanonicalJson().unmarshal(value, ItemTree.class));
-
+        ehrStatus.getOtherDetails().setArchetypeNodeId("other-details-test");
+        ehrStatus.getOtherDetails().setName(new DvText("test"));
 
         openEhrClient.ehrEndpoint().updateEhrStatus(ehrId, ehrStatus);
         EhrStatus actual = openEhrClient.ehrEndpoint().getEhrStatus(ehrId).get();


### PR DESCRIPTION
Adds fixes for more strict EHRbase validation of openEHR RM objects. Also makes creation of EHR more leaner defaulting to server side created status instance (otherwise the client side one would need to comply to stricter validation, too).